### PR TITLE
core-instrinctics, to core::mem::discriminant, but via the unsafe() mechanism

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -63,7 +63,7 @@ pub enum Attr {
 
 impl Attr {
     pub fn disc(&self) -> AttrDisc {
-        core::intrinsics::discriminant_value(self)
+        unsafe { *<*const _>::from(self).cast::<u8>() }
     }
 
     pub fn into_yang(self) -> Yang {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,6 @@
 #![no_std]
 
 #![cfg_attr(target_arch = "xtensa", feature(arbitrary_enum_discriminant))]
-#![feature(core_intrinsics)]
 
 #[cfg(feature = "std")]
 #[macro_use]

--- a/src/sid.rs
+++ b/src/sid.rs
@@ -155,7 +155,7 @@ macro_rules! to_attr {
 
 impl Sid {
     pub fn disc(&self) -> SidDisc {
-        core::intrinsics::discriminant_value(self)
+        unsafe { *<*const _>::from(self).cast::<u64>() }
     }
 
     pub fn as_attr(&self) -> Option<&crate::Attr> {

--- a/src/yang.rs
+++ b/src/yang.rs
@@ -24,7 +24,7 @@ pub enum Yang {
 
 impl Yang {
     pub fn disc(&self) -> YangDisc {
-        core::intrinsics::discriminant_value(self)
+        unsafe { *<*const _>::from(self).cast::<u8>() }
     }
 
     fn raw_enumeration(cbor: &CborType) -> Result<attr::Assertion, VoucherError> {


### PR DESCRIPTION
```
obiwan-[projects/trentonio/minerva-voucher](2.6.6) mcr 10683 %cargo build
   Compiling minerva-voucher v0.8.10 (/ssw/projects/trentonio/minerva-voucher)
warning: the feature `core_intrinsics` is internal to the compiler or standard library
   --> src/lib.rs:175:12
    |
175 | #![feature(core_intrinsics)]
    |            ^^^^^^^^^^^^^^^
    |
    = note: using it is strongly discouraged
    = note: `#[warn(internal_features)]` on by default

```

while reading: https://doc.rust-lang.org/core/mem/fn.discriminant.html
I tried to replace like:

```
        core::intrinsics::discriminant_value(self)
```

with:
```
core::mem::discriminant(self)
```

but that returns a Discriminant<T>, and I don't think that is helpful.
Reading further down, there is the unsafe() call, which this patch switches to.
Maybe that's a regression, and your opinion is sought.

